### PR TITLE
Ecs 247 problemas con el id de equipo tecnico en el esquema de la entidad de tecnicos

### DIFF
--- a/BackEnd/src/db/schema/schema.ts
+++ b/BackEnd/src/db/schema/schema.ts
@@ -111,7 +111,7 @@ export const Technician = pgTable('Technician', {
 	// 	onDelete: 'cascade',
 	// 	onUpdate: 'cascade'
 	// }),
-	technicalTeamId: serial().references(() => TechnicalTeam.id, {
+	technicalTeamId: integer().references(() => TechnicalTeam.id, {
 		onDelete: 'set null', // Si se elimina el equipo, el técnico queda sin equipo
 		onUpdate: 'cascade' // Si se actualiza el ID del equipo, se actualiza aquí
 	}),

--- a/BackEnd/src/db/schema/validationSchema.ts
+++ b/BackEnd/src/db/schema/validationSchema.ts
@@ -46,7 +46,7 @@ export const UserSchema = z.object({
 	updatedAt: z.date().optional(),
 	createdAt: z.date().optional(),
 	deletedAt: z.date().optional()
-});
+}).partial();
 
 // Esquema comentado para especialidades de técnicos (reemplazado por enum)
 // export const TechnicianSpecialitiesSchema = z.object({
@@ -64,10 +64,12 @@ export const UserSchema = z.object({
  * - Electronica: Especialidad en trabajos electrónicos
  */
 export const technicianSpecialityEnum = z.enum([
-	'Electricista',
-	'Mecanica',
-	'Logistica',
-	'Electronica'
+	'Electricidad',
+	'Refrigeracion',
+	'Iluminacion',
+	'Pintura',
+	'Protocolo',
+	'IT'
 ]);
 
 /**

--- a/BackEnd/src/db/schema/validationSchema.ts
+++ b/BackEnd/src/db/schema/validationSchema.ts
@@ -46,7 +46,7 @@ export const UserSchema = z.object({
 	updatedAt: z.date().optional(),
 	createdAt: z.date().optional(),
 	deletedAt: z.date().optional()
-}).partial();
+});
 
 // Esquema comentado para especialidades de técnicos (reemplazado por enum)
 // export const TechnicianSpecialitiesSchema = z.object({


### PR DESCRIPTION
Se cambió en el esquema de Drizzle que el TechnicalTeamId en Technician sea de tipo Integer en lugar de Serial, esto hacia que diera error al apuntar a un equipo que no existia,

También se cambio la tabla en supabase para que el TechnicalTeamId pueda ser nulo, y se quito el valor por default que tenia por ser Serial